### PR TITLE
INSTALL: specify proper target for lower yocto manual build

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -104,5 +104,5 @@ and using poky to build:
 
 cd workspace_base/build/tmp/work/x86_64-xt-linux/dom0-image-weston/1.0-r0/repo/
 source poky/oe-init-build-env
-bitbake xt-image
+bitbake core-image-weston
 


### PR DESCRIPTION
The lower yocto actual target is core-image-weston so it should be used for
a manual build.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>