### PR TITLE
Setting release to tags made for gen3test v3 alpha

### DIFF
--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH = "master"
 
-SRCREV = "${AUTOREV}"
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
 
 SRC_URI_append = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \

--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH = "master"
 
-SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6"
 
 SRC_URI_append = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 ################################################################################
 XEN_REL = "4.10"
 PV = "${XEN_REL}.0+git${SRCPV}"
-SRCREV = "be1f7ea9e535fb97688baa28dd9ef92a5d4fc52d" tag/RELEASE-4.10.0-xt0.5
+SRCREV = "be1f7ea9e535fb97688baa28dd9ef92a5d4fc52d"
 
 SRC_URI = " \
     git://github.com/xen-troops/xen.git;protocol=https;branch=master \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 ################################################################################
 XEN_REL = "4.10"
 PV = "${XEN_REL}.0+git${SRCPV}"
-SRCREV = "${AUTOREV}"
+SRCREV = "be1f7ea9e535fb97688baa28dd9ef92a5d4fc52d" tag/RELEASE-4.10.0-xt0.5
 
 SRC_URI = " \
     git://github.com/xen-troops/xen.git;protocol=https;branch=master \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH = "master"
-SRCREV = "${AUTOREV}"
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
 
 SRC_URI = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH = "master"
-SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6"
 
 SRC_URI = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displaymanager/displaymanager_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displaymanager/displaymanager_git.bbappend
@@ -1,4 +1,4 @@
-SRCREV = "6cbf0acec5d33a3be683e48a9cd4be4d16275fe5" tag/v0.1.1
+SRCREV = "6cbf0acec5d33a3be683e48a9cd4be4d16275fe5"
 
 SRC_URI_append = " git://github.com/xen-troops/DisplayManager.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displaymanager/displaymanager_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displaymanager/displaymanager_git.bbappend
@@ -1,4 +1,4 @@
-SRCREV = "${AUTOREV}"
+SRCREV = "6cbf0acec5d33a3be683e48a9cd4be4d16275fe5" tag/v0.1.1
 
 SRC_URI_append = " git://github.com/xen-troops/DisplayManager.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
@@ -1,7 +1,7 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "e3ea5359b6976bee38956d01899fc5fc2ebdbc00" tag/v0.2.1
+SRCREV_rcar = "e3ea5359b6976bee38956d01899fc5fc2ebdbc00"
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/displ_be.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
@@ -1,7 +1,7 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "${AUTOREV}"
+SRCREV_rcar = "e3ea5359b6976bee38956d01899fc5fc2ebdbc00" tag/v0.2.1
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/displ_be.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libxenbe/libxenbe_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libxenbe/libxenbe_git.bbappend
@@ -1,6 +1,6 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "${AUTOREV}"
+SRCREV_rcar = "d42279073e2a3303ae96f9b098a0bfb55ee13d87" tag/v0.2.3
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/libxenbe.git;protocol=https;branch=master"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libxenbe/libxenbe_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libxenbe/libxenbe_git.bbappend
@@ -1,6 +1,6 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "d42279073e2a3303ae96f9b098a0bfb55ee13d87" tag/v0.2.3
+SRCREV_rcar = "d42279073e2a3303ae96f9b098a0bfb55ee13d87"
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/libxenbe.git;protocol=https;branch=master"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/sndbe/sndbe_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/sndbe/sndbe_git.bbappend
@@ -1,7 +1,7 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "${AUTOREV}"
+SRCREV_rcar = "04caf58cecf262c00c21883987b996f733d9ccb5" tag/v0.2.1
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/snd_be.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/sndbe/sndbe_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/sndbe/sndbe_git.bbappend
@@ -1,7 +1,7 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "04caf58cecf262c00c21883987b996f733d9ccb5" tag/v0.2.1
+SRCREV_rcar = "04caf58cecf262c00c21883987b996f733d9ccb5"
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/snd_be.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -6,7 +6,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 XEN_REL_rcar = "4.10"
 PV = "${XEN_REL}.0+git${SRCPV}"
-SRCREV_rcar = "${AUTOREV}"
+SRCREV_rcar = "be1f7ea9e535fb97688baa28dd9ef92a5d4fc52d" tag/RELEASE-4.10.0-xt0.5
 
 SRC_URI_rcar = "git://github.com/xen-troops/xen.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -6,7 +6,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 XEN_REL_rcar = "4.10"
 PV = "${XEN_REL}.0+git${SRCPV}"
-SRCREV_rcar = "be1f7ea9e535fb97688baa28dd9ef92a5d4fc52d" tag/RELEASE-4.10.0-xt0.5
+SRCREV_rcar = "be1f7ea9e535fb97688baa28dd9ef92a5d4fc52d"
 
 SRC_URI_rcar = "git://github.com/xen-troops/xen.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,4 @@
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
-SRCREV = "${AUTOREV}"
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,4 @@
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
-SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -5,7 +5,7 @@ require inc/xt_shared_env.inc
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
-SRCREV = "${AUTOREV}"
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
 SRC_URI_append = " \
     file://defconfig \
 "

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -5,7 +5,7 @@ require inc/xt_shared_env.inc
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
-SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6"
 SRC_URI_append = " \
     file://defconfig \
 "

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -3,7 +3,7 @@ require inc/xt_shared_env.inc
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH = "master"
-SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6"
 
 SRC_URI = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -3,7 +3,7 @@ require inc/xt_shared_env.inc
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH = "master"
-SRCREV = "${AUTOREV}"
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
 
 SRC_URI = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,4 @@
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
-SRCREV = "${AUTOREV}"
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,4 @@
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
-SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -5,7 +5,7 @@ require inc/xt_shared_env.inc
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
-SRCREV = "${AUTOREV}"
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
 SRC_URI_append = " \
     file://defconfig \
 "

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -5,7 +5,7 @@ require inc/xt_shared_env.inc
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
-SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1
+SRCREV = "d6ea261d10b1f7eac577210761b7b7ce9f5f29d6"
 SRC_URI_append = " \
     file://defconfig \
 "


### PR DESCRIPTION
xen.git			"be1f7ea9e535fb97688baa28dd9ef92a5d4fc52d" tag/RELEASE-4.10.0-xt0.5
displ_be.git		"e3ea5359b6976bee38956d01899fc5fc2ebdbc00" tag/v0.2.1
snd_be.git		"04caf58cecf262c00c21883987b996f733d9ccb5" tag/v0.2.1
libxenbe.git		"d42279073e2a3303ae96f9b098a0bfb55ee13d87" tag/v0.2.3
DisplayManager.git	"6cbf0acec5d33a3be683e48a9cd4be4d16275fe5" tag/v0.1.1
linux.git		"d6ea261d10b1f7eac577210761b7b7ce9f5f29d6" tag/v4.14/rcar-3.6.2-xt0.1