### PR TITLE
Fix product manifests to point to prod_gen3_test

### DIFF
--- a/recipes-dom0/dom0-image-rescue-initramfs/dom0-image-rescue-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/dom0-image-rescue-initramfs.bbappend
@@ -5,7 +5,7 @@ do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
 do_compile[depends] += "domd-image-weston:do_${BB_DEFAULT_TASK}"
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/dom0.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_gen3_test/dom0.xml;scmdata=keep \
 "
 
 ###############################################################################

--- a/recipes-dom0/dom0-image-rescue-initramfs/dom0-image-rescue-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/dom0-image-rescue-initramfs.bbappend
@@ -5,7 +5,7 @@ do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
 do_compile[depends] += "domd-image-weston:do_${BB_DEFAULT_TASK}"
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_gen3_test/dom0.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;tag=v0.1;manifest=prod_gen3_test/dom0.xml;scmdata=keep \
 "
 
 ###############################################################################

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -22,7 +22,7 @@ python __anonymous () {
 ################################################################################
 # Generic ARMv8
 ################################################################################
-SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/dom0.xml;scmdata=keep"
+SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_gen3_test/dom0.xml;scmdata=keep"
 
 ###############################################################################
 # extra layers and files to be put after Yocto's do_unpack into inner builder

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -22,7 +22,7 @@ python __anonymous () {
 ################################################################################
 # Generic ARMv8
 ################################################################################
-SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_gen3_test/dom0.xml;scmdata=keep"
+SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;tag=v0.1;manifest=prod_gen3_test/dom0.xml;scmdata=keep"
 
 ###############################################################################
 # extra layers and files to be put after Yocto's do_unpack into inner builder

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domd.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_gen3_test/domd.xml;scmdata=keep \
 "
 
 SRC_URI_append = " \

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_gen3_test/domd.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;tag=v0.1;manifest=prod_gen3_test/domd.xml;scmdata=keep \
 "
 
 SRC_URI_append = " \

--- a/recipes-domu/domu-image-weston/domu-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/domu-image-weston.bbappend
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
 do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domu.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_gen3_test/domu.xml;scmdata=keep \
 "
 
 SRC_URI_append = " \

--- a/recipes-domu/domu-image-weston/domu-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/domu-image-weston.bbappend
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
 do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_gen3_test/domu.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;tag=v0.1;manifest=prod_gen3_test/domu.xml;scmdata=keep \
 "
 
 SRC_URI_append = " \


### PR DESCRIPTION
Some of the recipes point to prod_devel instead of prod_gen3_test.
Fix those by changing to prod_gen3_test.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>