### PR TITLE
Align Salvator-X/XS H3/M3 configuration w/ Salvator-X/XS 4x2G

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 
 # Initial memory allocation (MB)
-memory = 1024
+memory = 1536
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-m3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-m3ulcb.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=256M pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 
 # Initial memory allocation (MB)
-memory = 768
+memory = 1536
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 
 # Initial memory allocation (MB)
-memory = 1024
+memory = 1536
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 
 # Initial memory allocation (MB)
-memory = 1024
+memory = 1536
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=0"
 
 # Initial memory allocation (MB)
-memory = 1024
+memory = 1536
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-h3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-h3ulcb.cfg
@@ -14,12 +14,14 @@ device_tree = "/xt/domd/domu.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=1"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=1"
+extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
 
 # Initial memory allocation (MB)
 memory = 1536
+
+max_grant_frames = 64
 
 # Number of VCPUS
 vcpus = 4
@@ -40,7 +42,7 @@ vgsx = [ 'backend=DomD,osid=1' ]
 
 vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:ce' ]
 
-vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1024x768' ]
+vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080' ]
 
 vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1024,multi-touch-height=768,multi-touch-num-contacts=10,unique-id=T:1000,feature-disable-pointer=1,feature-disable-keyboard=1' ]
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-m3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-m3ulcb.cfg
@@ -14,12 +14,14 @@ device_tree = "/xt/domd/domu.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=1"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M pvrsrvkm.DriverMode=1"
+extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
 
 # Initial memory allocation (MB)
-memory = 768
+memory = 1536
+
+max_grant_frames = 64
 
 # Number of VCPUS
 vcpus = 4
@@ -40,7 +42,7 @@ vgsx = [ 'backend=DomD,osid=1' ]
 
 vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:ce' ]
 
-vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1024x768' ]
+vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080' ]
 
 vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1024,multi-touch-height=768,multi-touch-num-contacts=10,unique-id=T:1000,feature-disable-pointer=1,feature-disable-keyboard=1' ]
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-h3.cfg
@@ -14,12 +14,14 @@ device_tree = "/xt/domd/domu.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=1"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=1"
+extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
 
 # Initial memory allocation (MB)
 memory = 1536
+
+max_grant_frames = 64
 
 # Number of VCPUS
 vcpus = 4
@@ -40,7 +42,7 @@ vgsx = [ 'backend=DomD,osid=1' ]
 
 vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:ce' ]
 
-vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1024x768' ]
+vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080' ]
 
 vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1024,multi-touch-height=768,multi-touch-num-contacts=10,unique-id=T:1000,feature-disable-pointer=1,feature-disable-keyboard=1' ]
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-m3.cfg
@@ -14,12 +14,14 @@ device_tree = "/xt/domd/domu.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=1"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=384M pvrsrvkm.DriverMode=1"
+extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
 
 # Initial memory allocation (MB)
 memory = 1536
+
+max_grant_frames = 64
 
 # Number of VCPUS
 vcpus = 4
@@ -40,7 +42,7 @@ vgsx = [ 'backend=DomD,osid=1' ]
 
 vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:ce' ]
 
-vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1024x768' ]
+vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080' ]
 
 vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1024,multi-touch-height=768,multi-touch-num-contacts=10,unique-id=T:1000,feature-disable-pointer=1,feature-disable-keyboard=1' ]
 


### PR DESCRIPTION
Make CMA memory allocations, max number of grant references for DomU,
memory sizes and display configuration aligned with Salvator-X/XS
4x2G machines.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>