### PR TITLE
domd: Enable Weston V4L2 renderer

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
@@ -263,7 +263,7 @@ PREFERRED_PROVIDER_libgbm-dev = "libgbm"
 BBMASK .= "|mesa-gl"
 
 # Enable Multimedia features
-#MACHINE_FEATURES_append = " multimedia"
+MACHINE_FEATURES_append = " multimedia"
 
 # for gstreamer omx plugins
 LICENSE_FLAGS_WHITELIST = "commercial"
@@ -271,7 +271,7 @@ LICENSE_FLAGS_WHITELIST = "commercial"
 #DISTRO_FEATURES_append = " mm-test"
 
 # for weston v4l2 renderer
-#DISTRO_FEATURES_append = " v4l2-renderer"
+DISTRO_FEATURES_append = " v4l2-renderer"
 
 # OMX H263 decoder library for Linux (RTM0AC0000XV263D30SL41C)
 #DISTRO_FEATURES_append = " h263dec_lib"


### PR DESCRIPTION
[ prod-devel commit 0a7e56cad69300afb97862d1c8cb270230bc4afd ]

Enable Weston V4L2 renderer, which runs using VSPM device.
This change:
1. Enables vsp2/vspm kernel modules
2. Appends "--use-v4l2" argument to weston-launch/weston
3. Makes weston use v4l2 renderer

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Reviewed-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Reviewed-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>