### PR TITLE
Fix rcar-proprietary-graphic

### DIFF
--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/prepare-graphic-package.bb
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/prepare-graphic-package.bb
@@ -10,6 +10,7 @@ do_install () {
     if [ -d ${DEPLOY_DIR_IMAGE}/xt-rcar ]; then
         cd ${DEPLOY_DIR_IMAGE}
         date --rfc-3339=seconds > version.txt
+        sed -i 's/soc/passthrough/g' ${DEPLOY_DIR_IMAGE}/xt-rcar/etc/udev/rules.d/72-pvr-seat.rules
         tar -czf rcar-proprietary-graphic-${MACHINE}-domu.tar.gz xt-rcar version.txt
         rm version.txt
         rm -rf xt-rcar


### PR DESCRIPTION
Substitution of soc/passthrough is to late in do_install step
for gles-user-module recipe because build artiphacts already
copied in deploy directory, that is why substitution is missing
while preparing graphic package so make it in prepare graphic step.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>