### PR TITLE
domd:xen: Wildcard minor XEN version in xenpolicy file name

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -23,7 +23,7 @@ SRC_URI_append_r8a7796 = " \
 # Generic
 ################################################################################
 
-FLASK_POLICY_FILE = "xenpolicy-${XEN_REL}.0-rc"
+FLASK_POLICY_FILE = "xenpolicy-${XEN_REL}*"
 FILES_${PN}-flask = " \
     /boot/${FLASK_POLICY_FILE} \
 "


### PR DESCRIPTION
In order to not change xen bbappends in case of XEN minor versions
or -rc changes, wildcard the xenpolicy file name tail.
This will work under normal build conditions, might fail in case we
eventually, have several xenpolicy files in the folder (what is
assumed as abnormal).

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>