### PR TITLE
pm/cpufreq: Hook A53 cores clock up to voltage domain 1

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-4x2g-dom0.dts
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-4x2g-dom0.dts
@@ -83,19 +83,19 @@
 };
 
 &a53_0 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_1 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_2 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_3 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 /delete-node/&avs;

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-xs-4x2g-dom0.dts
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-xs-4x2g-dom0.dts
@@ -83,19 +83,19 @@
 };
 
 &a53_0 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_1 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_2 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_3 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 /delete-node/&avs;

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
@@ -69,19 +69,19 @@
 };
 
 &a53_0 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_1 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_2 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 &a53_3 {
-	/delete-property/clocks;
+	clocks = <&scpi_dvfs 1>;
 };
 
 /delete-node/&avs;


### PR DESCRIPTION
For the SCPI based CPUFreq to be able to pick A53 cores up and scale.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>