### PR TITLE
domd: add C++ header only log

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xt-log/xt-log_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xt-log/xt-log_git.bbappend
@@ -1,0 +1,2 @@
+SRC_URI = "git://github.com/xen-troops/${PN}.git"
+SRCREV = "${AUTOREV}"


### PR DESCRIPTION
cherry-picked from prod-devel: bc38452 domd: add C++ header only log

Add xt-log recipe.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>