### PR TITLE
domd: add C++ bindings for dbus

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/dbus/dbus-cxx_0.10.0.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/dbus/dbus-cxx_0.10.0.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;tag=${PV}"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displaymanager/displaymanager_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displaymanager/displaymanager_git.bbappend
@@ -2,6 +2,6 @@ SRCREV = "87e656daac312dcb3841968466098c95c746abdc"
 
 SRC_URI_append = " git://github.com/xen-troops/DisplayManager.git;protocol=https;branch=master"
 
-RDEPENDS_${PN} += " dbus-cpp"
+RDEPENDS_${PN} += " dbus-cxx"
 
 EXTRA_OECMAKE_append = " -DWITH_DOC=OFF -DCMAKE_BUILD_TYPE=Release"


### PR DESCRIPTION
cherry-picked from prod-devel: a22f1d0 domd: add C++ bindings for dbus

Add dbus-cxx recipe.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>