### PR TITLE
domd/domu: fix missing EGL/eglmesaext.h build error

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -24,6 +24,9 @@ do_populate_lic[noexec] = "1"
 do_compile[noexec] = "1"
 do_install[depends] += "linux-renesas:do_shared_workdir"
 
+# The gstreamer headers need headers from virtual/mesa.
+do_populate_sysroot[depends] += "virtual/mesa:do_populate_sysroot"
+
 do_install() {
     # Install configuration files
     install -d ${D}/${sysconfdir}/init.d

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -24,6 +24,9 @@ do_populate_lic[noexec] = "1"
 do_compile[noexec] = "1"
 do_install[depends] += "linux-renesas:do_shared_workdir"
 
+# The gstreamer headers need headers from virtual/mesa.
+do_populate_sysroot[depends] += "virtual/mesa:do_populate_sysroot"
+
 do_install() {
     # Install configuration files
     install -d ${D}/${sysconfdir}/init.d


### PR DESCRIPTION
Fix adopted from:
https://github.com/slawr/renesas-rcar-gen3
commit: 72302d0b400e17ed0c9983d13cae9d14d0619412

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>